### PR TITLE
temporary fix for cuisine build all go problm

### DIFF
--- a/lib/JumpScale/tools/cuisine/apps/CuisineAydoStor.py
+++ b/lib/JumpScale/tools/cuisine/apps/CuisineAydoStor.py
@@ -30,6 +30,7 @@ class AydoStor():
         @input addr, address and port on which the service need to listen. e.g. : 0.0.0.0:8090
         @input backend, directory where to save the data push to the store
         """
+        self.cuisine.core.dir_remove("%s/src" % self.cuisine.bash.environGet('GOPATH'))
         self.cuisine.golang.install()
         self.cuisine.golang.get("github.com/g8os/stor", action=True)
         self.cuisine.core.file_copy(self.cuisine.core.joinpaths(

--- a/lib/JumpScale/tools/cuisine/apps/CuisineCaddy.py
+++ b/lib/JumpScale/tools/cuisine/apps/CuisineCaddy.py
@@ -27,7 +27,7 @@ class Caddy():
     def build(self, ssl=False, start=True, dns=None):
         self.cuisine.golang.install()
         self.cuisine.golang.get("github.com/mholt/caddy", action=True)
-        self.cuisine.core.file_copy(self.cuisine.core.joinpaths('$goDir', 'bin', 'caddy'), '$binDir', action=True)
+        self.cuisine.core.file_copy(self.cuisine.core.joinpaths('$goDir', 'bin', 'caddy'), '$binDir')
         self.cuisine.bash.addPath(self.cuisine.core.args_replace("$binDir"), action=True)
 
         if ssl and dns:


### PR DESCRIPTION
the godep cannot handle the fact that some of the deps
are already installed and so halts the fix which was done by ashraf
to remove the src file before installing the service that causes the
problem which in this case is caddy , also minor bug fix file_copy has
no decorator and cannot call action