### PR TITLE
bug if firewall does nt exist will halt on caddy

### DIFF
--- a/lib/JumpScale/tools/cuisine/apps/CuisineCaddy.py
+++ b/lib/JumpScale/tools/cuisine/apps/CuisineCaddy.py
@@ -58,9 +58,12 @@ class Caddy():
     def start(self, ssl):
         cpath = self.cuisine.core.args_replace("$tmplsDir/cfg/caddy/caddyfile.conf")
         self.cuisine.processmanager.stop("caddy")  # will also kill
+        rc,_ = self.cuisine.core.run("ufw status", die=False)
         if ssl:
-            self.cuisine.fw.allowIncoming(443)
-            self.cuisine.fw.allowIncoming(80)
+            if not rc==1:
+                self.cuisine.fw.allowIncoming(443)
+                self.cuisine.fw.allowIncoming(80)
+
 
             if self.cuisine.process.tcpport_check(80, "") or self.cuisine.process.tcpport_check(443, ""):
                 raise RuntimeError("port 80 or 443 are occupied, cannot install caddy")
@@ -70,7 +73,9 @@ class Caddy():
                 raise RuntimeError("port 80 is occupied, cannot install caddy")
 
             PORTS = ":80"
-            self.cuisine.fw.allowIncoming(80)
+            if not rc==1:
+                self.cuisine.fw.allowIncoming(80)
+
         cmd = self.cuisine.bash.cmdGetPath("caddy")
         self.cuisine.processmanager.ensure("caddy", '%s -conf=%s -email=info@greenitglobe.com' % (cmd, cpath))
 


### PR DESCRIPTION
Added condidtion to check that ufw(firewall shell interface) runs correctly, if not
will not attempt to contact the firewall but also will not halt
execution.