### PR TITLE
quick gitlabinstance fixes and migration from j.base

### DIFF
--- a/lib/JumpScale/clients/gitlab/GitlabInstance.py
+++ b/lib/JumpScale/clients/gitlab/GitlabInstance.py
@@ -47,7 +47,7 @@ class GitlabInstance():
         # self.isLoggedIn = False
 
         #will be default 5 min
-        self.cache=j.db.cache.get(j.servers.kvs.getRedisStore(namespace="cache"))
+        self.cache=j.tools.cache.get(j.servers.kvs.getRedisStore(namespace="cache"))
 
     def getFile(self,group,project,path):
         """

--- a/lib/JumpScale/servers/key_value_store/redis_store.py
+++ b/lib/JumpScale/servers/key_value_store/redis_store.py
@@ -11,7 +11,7 @@ def chunks(l, n):
 class RedisKeyValueStore(KeyValueStoreBase):
     osis = dict()
 
-    def __init__(self,namespace="",host='localhost',port=7771,db=0,password='', serializers=[],masterdb=None, changelog=True):
+    def __init__(self,namespace="",host='localhost',port=6379,db=0,password='', serializers=[],masterdb=None, changelog=True):
 
         self.redisclient=j.clients.redis.get(host, port,password=password)
         self.redisclient.port=port

--- a/lib/JumpScale/tools/cache/Cache.py
+++ b/lib/JumpScale/tools/cache/Cache.py
@@ -16,6 +16,7 @@ class CacheFactory():
         """
         return Cache(db,expiration)
 
+
 class Cache():
 
     def __init__(self, db,expiration=300):
@@ -26,13 +27,13 @@ class Cache():
     def set(self,key,value):
         tostore={}
         tostore["val"]=value
-        tostore["expire"]=j.base.time.getTimeEpoch()+self.expiration
+        tostore["expire"]=j.data.time.getTimeEpoch()+self.expiration
         data=json.dumps(tostore)
         if self.redis:
             self.db.set("cache", key, data)
         else:
             self.db.set("cache", key, data,expire=self.expiration)
-        
+
     def get(self,key):
         """
         expire = bool, is true if expired


### PR DESCRIPTION
Fixes due to the addition of Cache tool 
*j.data.time.getTimeEpoch for Cache
*using j.tools.cache instead of j.db.cache 