### PR TITLE
bug fix in .profile_js + fix in sudo cmd

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -47,7 +47,7 @@ if [ "$(uname)" == "Darwin" ]; then
     export TMPDIR=~/tmp
 
     if [ -z"$JSBASE" ]; then
-        export JSBASE='~/opt/jumpscale8'
+        export JSBASE='$HOME/opt/jumpscale8'
     fi
     mkdir -p $TMPDIR
     cd $TMPDIR

--- a/install/reset.sh
+++ b/install/reset.sh
@@ -23,7 +23,7 @@ if [ "$(uname)" == "Darwin" ]; then
     export CODEDIR=~/opt/code
     
     if [ -z"$JSBASE" ]; then 
-        export JSBASE='~/opt/jumpscale8'
+        export JSBASE='$HOME/opt/jumpscale8'
     fi
     rm -rf $TMPDIR
     mkdir -p $TMPDIR

--- a/lib/JumpScale/tools/cuisine/CuisineCore.py
+++ b/lib/JumpScale/tools/cuisine/CuisineCore.py
@@ -1043,7 +1043,7 @@ class CuisineCore:
             cmd = cmd.replace('"', '\\"')
         if self.sudomode:
             passwd = self.executor.passwd if hasattr(self.executor, "passwd") else ''
-            cmd = 'echo %s | sudo -S bash -c "%s"' % (passwd, cmd)
+            cmd = 'echo %s | sudo -SE bash -c "%s"' % (passwd, cmd)
         else:
             cmd = 'bash -c "%s"' % cmd
 


### PR DESCRIPTION
-the .profile_js places the binDir as ~/opt/jumpscale8/bin
, but since ~ is not expanded in bash the path is not exposed and causes
errors.To fix this it was replaced with $HOME which is expandable in
bash

-the sudo cmd in mac defaults to reseting the env variable when running,
this causes problems as it removes the variable $TMPDIR, to avoid this,
a -E,  preserve env variables, was added to th command to stop it from
reseting