### PR TITLE
mac:bug fix location of known_hosts in cuisinegit

### DIFF
--- a/lib/JumpScale/tools/cuisine/CuisineGit.py
+++ b/lib/JumpScale/tools/cuisine/CuisineGit.py
@@ -17,7 +17,9 @@ class CuisineGit:
             dest = self.cuisine.core.args_replace(dest)
 
         self.cuisine.core.dir_ensure(dest)
-        self.cuisine.core.run("touch /root/.ssh/known_hosts && ssh-keyscan -H github.com >> /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts")
+        keys = self.cuisine.core.run("ssh-keyscan -H github.com")
+        self.cuisine.core.file_append("$homeDir/.ssh/known_hosts", keys)
+        self.cuisine.core.file_attribs("$homeDir/.ssh/known_hosts", mode=600)
 
         return j.do.pullGitRepo(url=url,dest=dest,login=login,passwd=passwd,depth=depth,\
             ignorelocalchanges=ignorelocalchanges,reset=reset,branch=branch,revision=revision, ssh=ssh,executor=self.executor)


### PR DESCRIPTION
location of known_hosts in cuisinegit is incorrect , as it assumes
the system is linux.Fixed to use the $homeDir variables which will
change with the system