### PR TITLE
mac: bug fix in actions + fs is not build on mac

### DIFF
--- a/lib/JumpScale/tools/actions/Action.py
+++ b/lib/JumpScale/tools/actions/Action.py
@@ -292,6 +292,7 @@ class Action:
     @method.setter
     def method(self,val):
         source = "".join(inspect.getsourcelines(val)[0])
+        source = self.selfobj.cuisine.core.args_replace(source)
         if source != "" and source[-1] != "\n":
             source += "\n"
         if source.strip().startswith("@"):
@@ -534,7 +535,6 @@ class Action:
         return self._selfobj
 
     def execute(self):
-
         self.check() #see about changed source code
 
         # if "$" in self.sourceToExecute:

--- a/lib/JumpScale/tools/cuisine/CuisineBuilder.py
+++ b/lib/JumpScale/tools/cuisine/CuisineBuilder.py
@@ -24,9 +24,9 @@ class CuisineBuilder:
         self.cuisine.apps.redis.build(start=start, force=True)
         if not self.cuisine.core.isMac:
             self.cuisine.apps.core.build(start=start)
+            self.cuisine.apps.fs.build(start=False)
         self.cuisine.apps.syncthing.build(start=start)
         self.cuisine.apps.controller.build(start=start)
-        self.cuisine.apps.fs.build(start=False)
         self.cuisine.apps.stor.build(start=start)
         self.cuisine.apps.etcd.build(start=start)
         self.cuisine.apps.caddy.build(start=start)

--- a/lib/JumpScale/tools/cuisine/CuisineCore.py
+++ b/lib/JumpScale/tools/cuisine/CuisineCore.py
@@ -212,7 +212,7 @@ class CuisineCore:
 
     def getenv(self):
         res = {}
-        for line in self.cuisine.core.run("printenv", profile=False, showout=False,force=True, replaceArgs=False).splitlines():
+        for line in self.cuisine.core.run("printenv", profile=False, showout=False,force=True, replaceArgs=False, action=False).splitlines():
             if '=' in line:
                 name,val = line.split("=",1)
                 name = name.strip()
@@ -531,10 +531,10 @@ class CuisineCore:
     def hostname(self):
         if self._hostname=="":
             if self.isMac:
-                self._hostname=self.run("hostname",showout=False,replaceArgs=False)
+                self._hostname=self.run("hostname",showout=False,replaceArgs=False, action=False)
             else:
                 hostfile="/etc/hostname"
-                self._hostname= self.run("cat %s"%hostfile,showout=False,replaceArgs=False).strip().split(".",1)[0]
+                self._hostname= self.run("cat %s"%hostfile,showout=False,replaceArgs=False, action=False).strip().split(".",1)[0]
         return self._hostname
 
     @hostname.setter

--- a/lib/JumpScale/tools/cuisine/apps/CuisineCaddy.py
+++ b/lib/JumpScale/tools/cuisine/apps/CuisineCaddy.py
@@ -58,7 +58,7 @@ class Caddy:
 
     def start(self, ssl):
         cpath = self.cuisine.core.args_replace("$cfgDir/caddy/caddyfile.conf")
-        self.cuisine.core.file_copy("$tmplsDir/cfg/caddy", "$cfgDir/caddy", recursive=True)
+        self.cuisine.core.file_copy("$tmplsDir/cfg/caddy", "$cfgDir/", recursive=True)
 
         #adjust confguration file
         conf = self.cuisine.core.file_read(cpath)


### PR DESCRIPTION
 - since fs extensivly uses syscall , a go library dedicated to
the linux kernel , it doesnt build therefor its not part of the sandbox
at the moment
 - actions replaced the $ env variables using a method from j.dirs,
this caused it to take the env varibales from the local host running the
command not the remote which its being executed on , so in mac for
example $homeDir should = /var/root but since the base is linux it
produces /root which is incorrect