### PR TITLE
mac: bug fix in CuisineInfluxdb

### DIFF
--- a/lib/JumpScale/tools/cuisine/apps/CuisineInfluxdb.py
+++ b/lib/JumpScale/tools/cuisine/apps/CuisineInfluxdb.py
@@ -30,6 +30,8 @@ class Influxdb:
         if self.cuisine.core.isMac:
             self.cuisine.package.mdupdate()
             self.cuisine.package.install('influxdb')
+            self.cuisine.core.dir_ensure("$tmplsDir/cfg/influxdb")
+            self.cuisine.core.file_copy("/usr/local/etc/influxdb.conf", "$tmplsDir/cfg/influxdb/influxdb.conf")
         if self.cuisine.core.isUbuntu:
             self.cuisine.core.dir_ensure("$tmplsDir/cfg/influxdb")
             C= """


### PR DESCRIPTION
the config file is not copied and so is not available when trying to use
to create the process exec