### PR TITLE
Enable STP on public vswitch

### DIFF
--- a/lib/JumpScale/sal/openvswitch/VXNet/utils.py
+++ b/lib/JumpScale/sal/openvswitch/VXNet/utils.py
@@ -85,7 +85,11 @@ def createBridge(name):
     r, s, e = doexec(cmd.split())
     if r:
         raise j.exceptions.RuntimeError("Problem with creation of bridge %s, err was: %s" % (name, e))
-
+    if name == "public":
+        cmd = '%s set Bridge %s stp_enable=true' % (vsctl,name)
+        r, s, e = doexec(cmd.split())
+        if r:
+            raise j.exceptions.RuntimeError("Problem setting STP on bridge %s, err was: %s" % (name, e))
 
 def destroyBridge(name):
     cmd = '%s --if-exists del-br %s' % (vsctl, name)


### PR DESCRIPTION
When an env is reconfigured to use another vlan, the old patches to the
public vswitch aren't removed. Adding another patch creates a loop,
causing a broadcast storm on the public vlan(s), sending the
network to binary heaven (and most certainly the uplink)

This enables STP on the public vswitch, to alleviate @least the uplink
from this broadcast storm

STP is 'good practice' on uplinks anyway, so let's put it as default.

This is a 'patch on a wooden leg' for misconfiguration, but just
a single stp should behave well enough