### PR TITLE
Improve how AYS repos are loaded and destroy

### DIFF
--- a/lib/JumpScale/baselib/atyourservice81/models/RepoModel.py
+++ b/lib/JumpScale/baselib/atyourservice81/models/RepoModel.py
@@ -41,6 +41,10 @@ class RepoModel(ModelBase):
             res.append(self._modelfactory.get(key))
         return res
 
+    def delete(self):
+        self._db.delete(self.key)
+        self._index.index_remove(self.path)
+
     def objectGet(self):
         """
         returns an Actor object created from this model


### PR DESCRIPTION
A repo model is now automaticly created during the loading of the repo
if it doesn't exist yet in db. so we don't force to discover the repo is
we load it manually

don't destroy the full repo bucket in database when we destroy one repo.
Now the repo is properly remove from db and other entries are left
intacts