### PR TITLE
8.2.0 aysardb

### DIFF
--- a/lib/JumpScale/baselib/atyourservice81/models/ActorsCollection.py
+++ b/lib/JumpScale/baselib/atyourservice81/models/ActorsCollection.py
@@ -14,7 +14,7 @@ class ActorsCollection(ModelBaseCollection):
     def __init__(self, repository):
         self.repository = repository
         namespace = "ays:%s:actor" % repository.name
-        db = j.servers.kvs.getRedisStore(namespace, namespace, **j.atyourservice.config['redis'])
+        db = j.servers.kvs.getARDBStore(namespace, namespace, **j.atyourservice.config['redis'])
         super().__init__(
             schema=ModelCapnp.Actor,
             category="Actor",

--- a/lib/JumpScale/baselib/atyourservice81/models/ReposCollection.py
+++ b/lib/JumpScale/baselib/atyourservice81/models/ReposCollection.py
@@ -13,7 +13,7 @@ class ReposCollections(ModelBaseCollection):
     #
 
     def __init__(self):
-        db = j.servers.kvs.getRedisStore("ays:repo", "ays:repo", **j.atyourservice.config['redis'])
+        db = j.servers.kvs.getARDBStore("ays:repo", "ays:repo", **j.atyourservice.config['redis'])
         super().__init__(schema=ModelCapnp.Repo, category="Repo", namespace="ays:repo", modelBaseClass=RepoModel, db=db, indexDb=db)
 
     def _list_keys(self, path="", returnIndex=False):

--- a/lib/JumpScale/baselib/atyourservice81/models/ServicesCollection.py
+++ b/lib/JumpScale/baselib/atyourservice81/models/ServicesCollection.py
@@ -14,7 +14,7 @@ class ServicesCollection(ModelBaseCollection):
     def __init__(self, repository):
         self.repository = repository
         namespace = "ays:%s:service" % repository.name
-        db = j.servers.kvs.getRedisStore(namespace, namespace, **j.atyourservice.config['redis'])
+        db = j.servers.kvs.getARDBStore(namespace, namespace, **j.atyourservice.config['redis'])
         super().__init__(
             schema=ModelCapnp.Service,
             category="Service",

--- a/lib/JumpScale/baselib/jobcontroller/models/ActionsCollection.py
+++ b/lib/JumpScale/baselib/jobcontroller/models/ActionsCollection.py
@@ -16,9 +16,9 @@ class ActionsCollection:
         self.category = "Action"
         self.namespace_prefix = 'jobs'
         namespace = "%s:%s" % (self.namespace_prefix, self.category.lower())
-        self._db = j.servers.kvs.getRedisStore(namespace, namespace, **j.atyourservice.config['redis'])
+        self._db = j.servers.kvs.getARDBStore(namespace, namespace, **j.atyourservice.config['redis'])
         # for now we do index same as database
-        self._index = j.servers.kvs.getRedisStore(namespace, namespace, **j.atyourservice.config['redis'])
+        self._index = j.servers.kvs.getARDBStore(namespace, namespace, **j.atyourservice.config['redis'])
 
     def new(self):
         model = ActionModel(

--- a/lib/JumpScale/baselib/jobcontroller/models/JobsCollections.py
+++ b/lib/JumpScale/baselib/jobcontroller/models/JobsCollections.py
@@ -17,9 +17,9 @@ class JobsCollection:
         self.category = "Job"
         self.namespace_prefix = 'jobs'
         namespace = "%s:%s" % (self.namespace_prefix, self.category.lower())
-        self._db = j.servers.kvs.getRedisStore(namespace, namespace, **j.atyourservice.config['redis'])
+        self._db = j.servers.kvs.getARDBStore(namespace, namespace, **j.atyourservice.config['redis'])
         # for now we do index same as database
-        self._index = j.servers.kvs.getRedisStore(namespace, namespace, **j.atyourservice.config['redis'])
+        self._index = j.servers.kvs.getARDBStore(namespace, namespace, **j.atyourservice.config['redis'])
 
     def new(self):
         model = JobModel(

--- a/lib/JumpScale/baselib/jobcontroller/models/RunsCollection.py
+++ b/lib/JumpScale/baselib/jobcontroller/models/RunsCollection.py
@@ -17,9 +17,9 @@ class RunsCollection:
         self.category = "Job"
         self.namespace_prefix = 'runs'
         namespace = "%s:%s" % (self.namespace_prefix, self.category.lower())
-        self._db = j.servers.kvs.getRedisStore(namespace, namespace, **j.atyourservice.config['redis'])
+        self._db = j.servers.kvs.getARDBStore(namespace, namespace, **j.atyourservice.config['redis'])
         # for now we do index same as database
-        self._index = j.servers.kvs.getRedisStore(namespace, namespace, **j.atyourservice.config['redis'])
+        self._index = j.servers.kvs.getARDBStore(namespace, namespace, **j.atyourservice.config['redis'])
 
     def new(self):
         model = RunModel(

--- a/lib/JumpScale/servers/key_value_store/StoreFactory.py
+++ b/lib/JumpScale/servers/key_value_store/StoreFactory.py
@@ -179,6 +179,37 @@ class StoreFactory:
 
         return res
 
+    def getARDBStore(self, name, namespace='db', host='localhost', port=16379, unixsocket=None, db=0, password='',
+                      serializers=None, masterdb=None, cache=None, changelog=None):
+        '''
+        Gets a memory key value store.
+
+        @param name: name of the store
+        @type name: String
+
+        @param namespace: namespace of the store, defaults to None
+        @type namespace: String
+
+        @return: key value store
+        @rtype: MemoryKeyValueStore
+        '''
+        from servers.key_value_store.ardb_store import ARDBKeyValueStore
+        res = ARDBKeyValueStore(
+            name=name,
+            namespace=namespace,
+            host=host,
+            port=port,
+            unixsocket=unixsocket,
+            db=db,
+            password=password,
+            serializers=serializers,
+            masterdb=masterdb,
+            changelog=changelog,
+            cache=cache
+        )
+
+        return res
+
     def _aclSerialze(self, acl={}):
         """
         access list

--- a/lib/JumpScale/servers/key_value_store/ardb_store.py
+++ b/lib/JumpScale/servers/key_value_store/ardb_store.py
@@ -1,0 +1,13 @@
+from servers.key_value_store.redis_store import RedisKeyValueStore
+from servers.key_value_store.store import KeyValueStoreBase
+from JumpScale import j
+
+
+class ARDBKeyValueStore(RedisKeyValueStore):
+
+    def __init__(self, name, namespace="db", host='localhost', port=6379, unixsocket=None, db=0, password='', serializers=[], masterdb=None, cache=None, changelog=None):
+        self.redisclient = j.clients.redis.get(host, port, password=password, unixsocket=unixsocket, ardb_patch=False)
+        KeyValueStoreBase.__init__(self, namespace=namespace, name=name, serializers=serializers,
+                                   masterdb=masterdb, cache=cache, changelog=changelog)
+        self._indexkey = "index:%s" % namespace
+        self.inMem = False

--- a/lib/JumpScale/servers/key_value_store/redis_store.py
+++ b/lib/JumpScale/servers/key_value_store/redis_store.py
@@ -44,8 +44,11 @@ class RedisKeyValueStore(KeyValueStoreBase):
         return self.redisclient.incr(self._getKey(key))
 
     def destroy(self):
+        # delete data
         for key in self.redisclient.keys(self.namespace + "*"):
             self.redisclient.delete(key)
+        # delete index to data
+        self.redisclient.delete(self._indexkey)
 
     def index(self, items, secret=""):
         """

--- a/lib/JumpScale/tools/cuisine/apps/CuisineARDB.py
+++ b/lib/JumpScale/tools/cuisine/apps/CuisineARDB.py
@@ -3,6 +3,7 @@ from JumpScale import j
 
 app = j.tools.cuisine._getBaseAppClass()
 
+
 class CuisineARDB(app):
     NAME = 'ardb'
 
@@ -21,12 +22,12 @@ class CuisineARDB(app):
         if reset:
             self.cuisine.core.run("rm -rf %s" % self.BUILDDIR)
 
-        #not needed to build separately is done in ardb automatically
+        # not needed to build separately is done in ardb automatically
         # self.buildForestDB(reset=reset)
 
-        self.buildARDB(reset=reset  )
+        self.buildARDB(reset=reset)
 
-    def buildForestDB(self,reset=False):
+    def buildForestDB(self, reset=False):
         if self.doneGet("buildforestdb") and not reset:
             return
 
@@ -54,7 +55,7 @@ class CuisineARDB(app):
         self.cuisine.core.run(self.replace(C))
         self.doneSet("buildforestdb")
 
-    def buildARDB(self,reset=False,storageEngine="forestdb"):
+    def buildARDB(self, reset=False, storageEngine="forestdb"):
         """
         @param storageEngine rocksdb or forestdb
         """
@@ -62,15 +63,14 @@ class CuisineARDB(app):
             return
 
         if self.cuisine.platformtype.isOSX():
-            storageEngine="rocksdb"
+            storageEngine = "rocksdb"
             # self.cuisine.package.install("boost")
 
         self.cuisine.package.install("wget")
 
-
         url = "git@github.com:yinqiwen/ardb.git"
         cpath = self.cuisine.development.git.pullRepo(url, tag="v0.9.3", reset=reset)
-        print (cpath)
+        print(cpath)
 
         assert cpath.rstrip("/") == self.CODEDIRARDB.rstrip("/")
 
@@ -84,13 +84,12 @@ class CuisineARDB(app):
             cp src/ardb-server $BUILDDIRARDB/
             cp ardb.conf $BUILDDIRARDB/
             """
-        C=C.replace("$storageEngine",storageEngine)
+        C = C.replace("$storageEngine", storageEngine)
         self.cuisine.core.run(self.replace(C))
 
         self.doneSet("buildardb")
 
-
-    def install(self, reset=False,start=True):
+    def install(self, reset=False, start=True):
         """
         as backend use ForestDB
         """
@@ -98,28 +97,24 @@ class CuisineARDB(app):
             return
         self.buildARDB()
 
-        self.core.file_copy("$BUILDDIR/ardb/ardb-server","$BINDIR/ardb-server")
-        self.core.file_copy("$BUILDDIR/ardb/ardb.conf","$CFGDIR/ardb.conf")
+        self.core.file_copy("$BUILDDIR/ardb/ardb-server", "$BINDIR/ardb-server")
+        self.core.file_copy("$BUILDDIR/ardb/ardb.conf", "$CFGDIR/ardb.conf")
 
-        config=self.core.file_read("$CFGDIR/ardb.conf")
-        datadir=self.replace("$VARDIR/data/ardb")
-        config=config.replace("${ARDB_HOME}",datadir)
-        config=config.replace("0.0.0.0:16379","localhost:16379")
-
+        config = self.core.file_read("$CFGDIR/ardb.conf")
+        datadir = self.replace("$VARDIR/data/ardb")
+        config = config.replace("home  ..", "home {}".format(datadir))
+        config = config.replace("redis-compatible-mode     no", "redis-compatible-mode     yes")
+        config = config.replace("redis-compatible-version  2.8.0", "redis-compatible-version  3.5.2")
+        config = config.replace("0.0.0.0:16379", "localhost:16379")
 
         self.core.dir_ensure(datadir)
 
-        self.core.file_write("$CFGDIR/ardb.conf",config)
+        self.core.file_write("$CFGDIR/ardb.conf", config)
 
         self.doneSet("install")
 
         if start:
             self.start()
-
-
-    # def start(self, name="main", ip="localhost", port=6379, maxram=200, appendonly=True,
-    #           snapshot=False, slave=(), ismaster=False, passwd=None):
-        # raise NotImplementedError
 
     def start(self, reset=False):
         if not reset and self.doneGet("start"):
@@ -135,17 +130,14 @@ class CuisineARDB(app):
     def stop(self):
         self.cuisine.processmanager.stop("ardb-server")
 
-
     def getClient(self):
         pass
-
-
 
     def test(self):
         """
         do some test through normal redis client
         """
-        r=j.clients.redis.get(port=16379)
-        r.set("test","test")
-        assert r.get("test")==b"test"
+        r = j.clients.redis.get(port=16379)
+        r.set("test", "test")
+        assert r.get("test") == b"test"
         r.delete("test")

--- a/lib/JumpScale/tools/cuisine/apps/CuisineARDB.py
+++ b/lib/JumpScale/tools/cuisine/apps/CuisineARDB.py
@@ -103,8 +103,6 @@ class CuisineARDB(app):
         config = self.core.file_read("$CFGDIR/ardb.conf")
         datadir = self.replace("$VARDIR/data/ardb")
         config = config.replace("home  ..", "home {}".format(datadir))
-        config = config.replace("redis-compatible-mode     no", "redis-compatible-mode     yes")
-        config = config.replace("redis-compatible-version  2.8.0", "redis-compatible-version  3.5.2")
         config = config.replace("0.0.0.0:16379", "localhost:16379")
 
         self.core.dir_ensure(datadir)

--- a/lib/JumpScale/tools/path/PathFactory.py
+++ b/lib/JumpScale/tools/path/PathFactory.py
@@ -1,4 +1,4 @@
-from path import path
+from path import Path
 
 
 class PathFactory:
@@ -21,4 +21,4 @@ class PathFactory:
         files = d.walkfiles("*.pyc")
         num_files = len(d.files())
         """
-        return path(startpath)
+        return Path(startpath)


### PR DESCRIPTION
This is a branch to test the viablity of ardb as a replacement of redis for AYS.

To test:
- build and start ardb. There is a cuisine module that does it for you.
- make sure that ays config points to the ardb instance and not redis. By default ardb listen on port `16379`