### PR TITLE
cuisine portal fixes for mac

### DIFF
--- a/lib/JumpScale/tools/cuisine/CuisineCore.py
+++ b/lib/JumpScale/tools/cuisine/CuisineCore.py
@@ -711,6 +711,8 @@ class CuisineCore(base):
                 content_base64 = base64.b64encode(content2).decode()
                 # if sig != self.file_md5(location):
                 cmd = 'echo "%s" | base64 -d > %s' % (content_base64, location)
+                if self.isMac:
+                    cmd = 'echo "%s" | base64 -D > %s' % (content_base64, location)          
                 res = self.run(cmd, showout=False)
             if check:
                 file_sig = self.file_md5(location)

--- a/lib/JumpScale/tools/cuisine/CuisineProcessManager.py
+++ b/lib/JumpScale/tools/cuisine/CuisineProcessManager.py
@@ -9,7 +9,7 @@ base = j.tools.cuisine._getBaseClass()
 class ProcessManagerBase(base):
 
     def __init__(self, executor, cuisine):
-        self.startupfile = '/etc/startup.sh'
+        self.startupfile = "%s/startup.sh" % j.dirs.BINDIR
         self.executor = executor
         self._cuisine = cuisine
         self._logger = j.logger.get('j.cuisine.processmanager')

--- a/lib/JumpScale/tools/cuisine/apps/CuisinePortal.py
+++ b/lib/JumpScale/tools/cuisine/apps/CuisinePortal.py
@@ -1,5 +1,7 @@
 from JumpScale import j
 import time
+import os
+
 
 
 base = j.tools.cuisine._getBaseClass()
@@ -201,7 +203,7 @@ class CuisinePortal(base):
 
     def getcode(self, branch=''):
         if branch == "":
-            branch = "8.2.0_portal_cleanup"
+            branch = os.environ.get('JSBRANCH')
         self.cuisine.development.git.pullRepo(
             "https://github.com/Jumpscale/jumpscale_portal8.git", branch=branch)
 


### PR DESCRIPTION
- branch hardcoded in portal changed to use JSBRANCH varaible instead
- base64 in mac uses -D instead of -d
- jumpscale on macosx doesnt have write access on /etc , changed
  startup.sh to bindir.