### PR TITLE
bug fix in cuisine process manager loading

### DIFF
--- a/lib/JumpScale/core/main/Dirs.py
+++ b/lib/JumpScale/core/main/Dirs.py
@@ -40,6 +40,7 @@ class Dirs:
         self.HOMEDIR = os.environ["HOME"]
         self.CFGDIR = os.environ["CFGDIR"]
         self.TMPDIR = os.environ["TMPDIR"]
+        self.init()
 
     def normalize(self, path):
         """


### PR DESCRIPTION
 - j.dirs, no longer has BINDIR used replacetext in args instead